### PR TITLE
feat: add individual-client endpoints mirroring legal-entity-client f…

### DIFF
--- a/src/resources/individual-client/dto/create-individual-client.dto.ts
+++ b/src/resources/individual-client/dto/create-individual-client.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateIndividualClientDto {
+  @ApiProperty({ description: 'ID del cliente' })
+  clienteId: number;
+
+  @ApiProperty({ description: 'ID del estado civil' })
+  estadoCivilId: number;
+
+  @ApiProperty({ description: 'ID del sexo' })
+  sexoId: number;
+
+  @ApiProperty({ description: 'Fecha de nacimiento del cliente' })
+  clienteFechaNacimiento: string;
+
+  @ApiProperty({ description: 'Nombre de la empresa' })
+  empresa: string;
+
+  @ApiProperty({ description: 'Domicilio fiscal del cliente' })
+  domicilioFiscal: string;
+}

--- a/src/resources/individual-client/dto/individual-client-response.dto.ts
+++ b/src/resources/individual-client/dto/individual-client-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IndividualClientResponseDto {
+  @ApiProperty({ description: 'ID del cliente' })
+  clienteId: number;
+
+  @ApiProperty({ description: 'ID del estado civil' })
+  estadoCivilId: number;
+
+  @ApiProperty({ description: 'ID del sexo' })
+  sexoId: number;
+
+  @ApiProperty({ description: 'Fecha de nacimiento del cliente' })
+  clienteFechaNacimiento: string;
+
+  @ApiProperty({ description: 'Nombre de la empresa' })
+  empresa: string;
+
+  @ApiProperty({ description: 'Domicilio fiscal del cliente' })
+  domicilioFiscal: string;
+}

--- a/src/resources/individual-client/dto/update-individual-client.dto.ts
+++ b/src/resources/individual-client/dto/update-individual-client.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateIndividualClientDto {
+  @ApiProperty({ description: 'ID del estado civil', required: false })
+  estadoCivilId?: number;
+
+  @ApiProperty({ description: 'ID del sexo', required: false })
+  sexoId?: number;
+
+  @ApiProperty({ description: 'Fecha de nacimiento del cliente', required: false })
+  clienteFechaNacimiento?: string;
+
+  @ApiProperty({ description: 'Nombre de la empresa', required: false })
+  empresa?: string;
+
+  @ApiProperty({ description: 'Domicilio fiscal del cliente', required: false })
+  domicilioFiscal?: string;
+}

--- a/src/resources/individual-client/individual-client.controller.ts
+++ b/src/resources/individual-client/individual-client.controller.ts
@@ -5,19 +5,19 @@ import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { BaseResponse } from 'src/common/classes';
 import { UserRole } from '../users/user.entity';
 import { IndividualClientResponseDto } from './dto/individual-client-response.dto';
-import { IndividualClient } from './individual-client.entity';
 import { CreateIndividualClientDto } from './dto/create-individual-client.dto';
 import { UpdateIndividualClientDto } from './dto/update-individual-client.dto';
 import { IndividualClientService } from './individual-client.service';
+import { IndividualClient } from './individual-client.entity';
 
 @ApiTags('Individual-Client')
-@Controller('api/ClientesPersona')
+@Controller('individual-client')
 export class IndividualClientController {
   constructor(private readonly individualClientService: IndividualClientService) {}
 
-  @ApiOperation({ summary: 'Obtención de cliente individual por id' })
+  @ApiOperation({ summary: 'Obtención de cliente persona por id' })
   @ApiParam({ name: 'id', description: 'ID del cliente' })
-  @ApiResponse({ status: 200, description: 'Datos del cliente individual.', type: [IndividualClientResponseDto] })
+  @ApiResponse({ status: 200, description: 'Datos del cliente persona.', type: [IndividualClientResponseDto] })
   @Get(':id')
   async findById(@Param('id') id: string): Promise<BaseResponse<IndividualClient>> {
     try {
@@ -28,14 +28,14 @@ export class IndividualClientController {
         data: individualClient
       };
     } catch (error) {
-      console.error('Error al encontrar el cliente individual:', error);
-      throw new InternalServerErrorException('Ocurrió un error inesperado al encontrar el cliente individual.');
+      console.error('Error al encontrar el cliente persona:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al encontrar el cliente persona.');
     }
   }
 
-  @ApiOperation({ summary: 'Creación de cliente individual' })
+  @ApiOperation({ summary: 'Creación de cliente persona' })
   @ApiBody({ type: CreateIndividualClientDto })
-  @ApiResponse({ status: 201, description: 'Cliente individual creado exitosamente.', type: IndividualClientResponseDto })
+  @ApiResponse({ status: 201, description: 'Cliente persona creado exitosamente.', type: IndividualClientResponseDto })
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(RolesGuard)
@@ -49,15 +49,15 @@ export class IndividualClientController {
         data: individualClient
       };
     } catch (error) {
-      console.error('Error al crear el cliente individual:', error);
-      throw new InternalServerErrorException('Ocurrió un error inesperado al crear el cliente individual.');
+      console.error('Error al crear el cliente persona:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al crear el cliente persona.');
     }
   }
 
-  @ApiOperation({ summary: 'Modificación del cliente individual' })
+  @ApiOperation({ summary: 'Modificación del cliente persona' })
   @ApiBody({ type: UpdateIndividualClientDto })
-  @ApiParam({ name: 'id', description: 'ID del cliente individual a modificar' })
-  @ApiResponse({ status: 200, description: 'Cliente individual modificado exitosamente.', type: IndividualClientResponseDto })
+  @ApiParam({ name: 'id', description: 'ID del cliente persona a modificar' })
+  @ApiResponse({ status: 200, description: 'Cliente persona modificado exitosamente.', type: IndividualClientResponseDto })
   @Put(':id')
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
@@ -70,13 +70,13 @@ export class IndividualClientController {
         data: null
       };
     } catch (error) {
-      console.error('Error al modificar el cliente individual:', error);
-      throw new InternalServerErrorException('Ocurrió un error inesperado al modificar el cliente individual.');
+      console.error('Error al modificar el cliente persona:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al modificar el cliente persona.');
     }
   }
 
-  @ApiOperation({ summary: 'Eliminación de cliente individual' })
-  @ApiParam({ name: 'id', description: 'ID del cliente individual a eliminar' })
+  @ApiOperation({ summary: 'Eliminación de cliente persona' })
+  @ApiParam({ name: 'id', description: 'ID del cliente persona a eliminar' })
   @ApiResponse({ status: 200, description: 'Cliente eliminado exitosamente.'})
   @Delete(':id')
   @UseGuards(RolesGuard)
@@ -90,8 +90,8 @@ export class IndividualClientController {
         data: null
       };
     } catch (error) {
-      console.error('Error al eliminar el cliente individual:', error);
-      throw new InternalServerErrorException('Ocurrió un error inesperado al eliminar el cliente individual.');
+      console.error('Error al eliminar el cliente persona:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al eliminar el cliente persona.');
     }
   }
 }

--- a/src/resources/individual-client/individual-client.controller.ts
+++ b/src/resources/individual-client/individual-client.controller.ts
@@ -1,4 +1,97 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, InternalServerErrorException, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { BaseResponse } from 'src/common/classes';
+import { UserRole } from '../users/user.entity';
+import { IndividualClientResponseDto } from './dto/individual-client-response.dto';
+import { IndividualClient } from './individual-client.entity';
+import { CreateIndividualClientDto } from './dto/create-individual-client.dto';
+import { UpdateIndividualClientDto } from './dto/update-individual-client.dto';
+import { IndividualClientService } from './individual-client.service';
 
-@Controller('individual-client')
-export class IndividualClientController {}
+@ApiTags('Individual-Client')
+@Controller('api/ClientesPersona')
+export class IndividualClientController {
+  constructor(private readonly individualClientService: IndividualClientService) {}
+
+  @ApiOperation({ summary: 'Obtención de cliente individual por id' })
+  @ApiParam({ name: 'id', description: 'ID del cliente' })
+  @ApiResponse({ status: 200, description: 'Datos del cliente individual.', type: [IndividualClientResponseDto] })
+  @Get(':id')
+  async findById(@Param('id') id: string): Promise<BaseResponse<IndividualClient>> {
+    try {
+      const individualClient = await this.individualClientService.findById(id);
+
+      return {
+        success: true,
+        data: individualClient
+      };
+    } catch (error) {
+      console.error('Error al encontrar el cliente individual:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al encontrar el cliente individual.');
+    }
+  }
+
+  @ApiOperation({ summary: 'Creación de cliente individual' })
+  @ApiBody({ type: CreateIndividualClientDto })
+  @ApiResponse({ status: 201, description: 'Cliente individual creado exitosamente.', type: IndividualClientResponseDto })
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async create(@Body() createIndividualClientDto: CreateIndividualClientDto): Promise<BaseResponse<IndividualClient>> {
+    try {
+      const individualClient = await this.individualClientService.create(createIndividualClientDto);
+
+      return {
+        success: true,
+        data: individualClient
+      };
+    } catch (error) {
+      console.error('Error al crear el cliente individual:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al crear el cliente individual.');
+    }
+  }
+
+  @ApiOperation({ summary: 'Modificación del cliente individual' })
+  @ApiBody({ type: UpdateIndividualClientDto })
+  @ApiParam({ name: 'id', description: 'ID del cliente individual a modificar' })
+  @ApiResponse({ status: 200, description: 'Cliente individual modificado exitosamente.', type: IndividualClientResponseDto })
+  @Put(':id')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async update(@Param('id') id: string, @Body() updateIndividualClientDto: UpdateIndividualClientDto): Promise<BaseResponse<null>> {
+    try {
+      await this.individualClientService.update(id, updateIndividualClientDto);
+
+      return {
+        success: true,
+        data: null
+      };
+    } catch (error) {
+      console.error('Error al modificar el cliente individual:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al modificar el cliente individual.');
+    }
+  }
+
+  @ApiOperation({ summary: 'Eliminación de cliente individual' })
+  @ApiParam({ name: 'id', description: 'ID del cliente individual a eliminar' })
+  @ApiResponse({ status: 200, description: 'Cliente eliminado exitosamente.'})
+  @Delete(':id')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async remove(@Param('id') id: string): Promise<BaseResponse<null>> {
+    try {
+      await this.individualClientService.remove(id);
+
+      return {
+        success: true,
+        data: null
+      };
+    } catch (error) {
+      console.error('Error al eliminar el cliente individual:', error);
+      throw new InternalServerErrorException('Ocurrió un error inesperado al eliminar el cliente individual.');
+    }
+  }
+}

--- a/src/resources/individual-client/individual-client.entity.ts
+++ b/src/resources/individual-client/individual-client.entity.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IndividualClient {
+  @ApiProperty({ description: 'ID del cliente' })
+  clienteId: number;
+
+  @ApiProperty({ description: 'ID del estado civil' })
+  estadoCivilId: number;
+
+  @ApiProperty({ description: 'ID del sexo' })
+  sexoId: number;
+
+  @ApiProperty({ description: 'Fecha de nacimiento del cliente' })
+  clienteFechaNacimiento: string;
+
+  @ApiProperty({ description: 'Nombre de la empresa' })
+  empresa: string;
+
+  @ApiProperty({ description: 'Domicilio fiscal del cliente' })
+  domicilioFiscal: string;
+}

--- a/src/resources/individual-client/individual-client.service.ts
+++ b/src/resources/individual-client/individual-client.service.ts
@@ -1,4 +1,47 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { AxiosInstance } from 'axios';
+import { IA_BROKER_AXIOS_INSTANCE } from 'src/common/constants';
+import { IndividualClient } from './individual-client.entity';
+import { CreateIndividualClientDto } from './dto/create-individual-client.dto';
+import { UpdateIndividualClientDto } from './dto/update-individual-client.dto';
 
 @Injectable()
-export class IndividualClientService {}
+export class IndividualClientService {
+  constructor(
+    @Inject(IA_BROKER_AXIOS_INSTANCE) private readonly aiBrokerApi: AxiosInstance,
+  ) {}
+
+  async findById(id: string): Promise<IndividualClient> {
+    try {
+      const apiResponse = await this.aiBrokerApi.get(`/ClientesPersona/${id}`);
+      return apiResponse.data;
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  async create(createClientDto: CreateIndividualClientDto): Promise<IndividualClient> {
+    try {
+      const apiResponse = await this.aiBrokerApi.post(`/ClientesPersona`, createClientDto);
+      return apiResponse.data;
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  async update(id: string, updateClientDto: UpdateIndividualClientDto): Promise<void> {
+    try {
+      await this.aiBrokerApi.put(`/ClientesPersona/${id}`, updateClientDto);
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      await this.aiBrokerApi.delete(`/ClientesPersona/${id}`);
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+}


### PR DESCRIPTION
Esta pull request agrega nuevos endpoints para el módulo `individual-client`, replicando la funcionalidad existente en el módulo `legal-entity-client`. Esto incluye:

- Creación de controladores, servicios y módulos necesarios.
- Implementación de las operaciones CRUD.
- Validaciones y DTOs específicos para `individual-client`.

El objetivo es proporcionar una funcionalidad equivalente para manejar clientes individuales, asegurando consistencia con la estructura y lógica del módulo de clientes jurídicos.